### PR TITLE
v1の廃止に伴うv2移行用サンプルデザインの追加

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 PAY, inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/sample/payjp-js/base.css
+++ b/sample/payjp-js/base.css
@@ -1,0 +1,79 @@
+:root {
+  --payjp-primary-color: #198fcc;
+  --invalid-color: #b00020;
+}
+
+main {
+  margin: 0 auto;
+  padding: 0 20px;
+  max-width: 800px;
+}
+
+main a {
+  color: #198fcc;
+  color: var(--payjp-primary-color);
+  text-decoration: none;
+}
+
+main > section {
+  justify-content: center;
+  position: relative;
+  box-shadow: 0 6px 6px 0 rgba(0, 0, 0, 0.12);
+  margin-left: -20px;
+  margin-right: -20px;
+  padding: 80px 0px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+main > section + section {
+  margin-top: 50px;
+}
+
+main > section form {
+  position: relative;
+  width: 100%;
+  max-width: 500px;
+  transition-property: opacity, transform;
+  transition-duration: 0.3s;
+  transition-timing-function: linear;
+}
+
+@media (min-width: 670px) {
+  main > section {
+    padding: 40px;
+  }
+  main > section .success {
+    padding: 40px;
+  }
+}
+
+main > section .success {
+  position: absolute;
+  text-align: center;
+  pointer-events: none;
+  opacity: 0;
+}
+
+main > section form.submitted,
+main > section form.submitting {
+  opacity: 0;
+  transform: scale(0.8);
+  pointer-events: none;
+}
+
+main > section form.submitted + .success {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+main > section .error {
+  opacity: 0;
+  color: #b00020;
+  color: var(--invalid-color);
+}
+
+main > section .error.visible {
+  opacity: 1;
+}

--- a/sample/payjp-js/index.html
+++ b/sample/payjp-js/index.html
@@ -3,252 +3,81 @@
 <head>
 <meta charset="utf-8">
 <meta content="width=device-width,initial-scale=1.0" name="viewport">
-<title>payjp.js v2 Sample</title>
+<title>payjp.js v2 design samples</title>
 <script type="text/javascript" src="https://js.pay.jp/v2/"></script>
-<!-- for IE11 --><script src="https://cdnjs.cloudflare.com/ajax/libs/bluebird/3.3.4/bluebird.min.js"></script>
-<style media="screen">
-main {
-  margin: 0 auto;
-  padding: 0 20px;
-  max-width: 800px;
-}
-
-p.semantic {
-  line-height: 1.4285em;
-}
-
-.semantic a {
-  background: 0 0;
-  color: #198fcc;
-  text-decoration: none;
-}
-
-main > section {
-  justify-content: center;
-  position: relative;
-  box-shadow: 0 6px 6px 0 rgba(0, 0, 0, 0.12);
-  margin-left: -20px;
-  margin-right: -20px;
-  padding: 80px 0px;
-  display: flex;
-}
-
-main > section + section {
-  margin-top: 50px;
-}
-
-main > section > form {
-  position: relative;
-  width: 100%;
-  max-width: 500px;
-  transition-property: opacity, transform;
-  transition-duration: 0.3s;
-  transition-timing-function: linear;
-}
-
-@media (min-width: 670px) {
-  main > section {
-    padding: 40px;
-  }
-  main > section .success {
-    padding: 40px;
-  }
-}
-
-form.submitted,
-form.submitting {
-  opacity: 0;
-  transform: scale(0.9);
-  pointer-events: none;
-}
-
-form.submitting + .success {
-  opacity: 1;
-}
-
-form.submitted + .success > * {
-  opacity: 1;
-  transform: none !important;
-  pointer-events: auto;
-}
-
-main > section .success {
-  position: absolute;
-  width: 100%;
-  padding: 10px;
-  text-align: center;
-  pointer-events: none;
-}
-
-main > section .success > * {
-  transition-property: opacity, transform;
-  transition-duration: 0.4s;
-  transition-timing-function: linear;
-  opacity: 0;
-  transform: translateY(50px);
-}
-
-section.example-mdc .success .message {
-  color: grey;
-}
-
-main > section .error {
-  padding: 0 15px;
-  opacity: 0;
-  transform: translateY(10px);
-  transition-property: opacity, transform;
-  transition-duration: 0.3s;
-  transition-timing-function: linear;
-}
-
-main > section .error.visible {
-  opacity: 1;
-  transform: none;
-}
-
-main > section .error .message {
-  font-size: 13px;
-  color: red;
-}
-
-section.example-mdc * {
-  font-family: 'Noto Sans Japanese', sans-serif;
-  font-size: 16px;
-  font-weight: 500;
-  outline: none;
-  border-style: none;
-}
-
-section.example-mdc .row {
-  display: flex;
-  margin: 0 5px 10px;
-}
-
-section.example-mdc .field {
-  position: relative;
-  width: 100%;
-  height: 50px;
-  margin: 0 10px;
-}
-
-section.example-mdc .field.half-width {
-  width: 50%;
-}
-
-section.example-mdc .baseline {
-  position: absolute;
-  width: 100%;
-  height: 1px;
-  bottom: 0;
-  background-color: lightgrey;
-  transition: background-color 0.3s linear;
-}
-
-section.example-mdc label {
-  position: absolute;
-  transform-origin: 0 50%;
-  bottom: 8px;
-  color: #999;
-  transition-property: color, transform;
-  transition-duration: 0.3s;
-  transition-timing-function: ease-out;
-}
-
-section.example-mdc button {
-  width: calc(100% - 30px);
-  height: 40px;
-  margin: 20px 15px 0;
-  background-color: #198fcc;
-  border-radius: 4px;
-  color: #fff;
-  cursor: pointer;
-}
-
-section.example-mdc .input {
-  position: absolute;
-  width: 100%;
-  bottom: 0;
-  padding-bottom: 5px;
-}
-
-section.example-mdc .input::-webkit-input-placeholder {
-  color: #E0E0E0;
-}
-
-section.example-mdc .input::-moz-placeholder {
-  color: #E0E0E0;
-}
-
-section.example-mdc .input:-ms-input-placeholder {
-  color: #E0E0E0;
-}
-
-section.example-mdc .input.PayjpElement {
-  opacity: 0;
-}
-
-section.example-mdc .input.PayjpElement--focus,
-section.example-mdc .input:not(.PayjpElement--empty) {
-  opacity: 1;
-}
-
-section.example-mdc .input.PayjpElement--focus + label,
-section.example-mdc .input:not(.PayjpElement--empty) + label {
-  color: #198fcc;
-  transform: scale(0.85) translateY(-25px);
-}
-
-section.example-mdc .input.PayjpElement--invalid + label {
-  color: red;
-}
-
-section.example-mdc .input.PayjpElement--focus + label + .baseline {
-  background-color: #198fcc;
-}
-
-section.example-mdc .input.PayjpElement--focus.PayjpElement--invalid + label + .baseline {
-  background-color: red;
-}
+<!-- for IE11 -->
+<script>
+  window.MSInputMethodContext
+  && document.documentMode
+  && document.write(
+    '<script src="https://cdnjs.cloudflare.com/ajax/libs/bluebird/3.3.4/bluebird.min.js"><\/script>'
+  )
+</script>
+<!-- end: for IE11 -->
+<!-- material design library -->
+<script src="https://unpkg.com/material-components-web@latest/dist/material-components-web.min.js"></script>
+<link href="https://unpkg.com/material-components-web@latest/dist/material-components-web.min.css" rel="stylesheet">
+<!-- end: material design library -->
+<link rel="stylesheet" type="text/css" href="base.css" />
+<link rel="stylesheet" type="text/css" href="mdc-common.css" />
+<link rel="stylesheet" type="text/css" href="mdc-on-v2.css" />
+<style>
 </style>
 </head>
 <body>
-
 <main>
-<h1>payjp.js v2 Design Samples</h1>
-<p class="semantic">テストカードは<a href="https://pay.jp/docs/testcard" target="_blank">こちら</a></p>
-<p class="semantic">このフォームのソースコードは<a href="https://github.com/payjp/payjp.github.io/blob/master/sample/payjp-js/index.html" target="_blank">こちら</a></p>
-<section class="example-mdc">
+<h1>payjp.js v2 決済フォーム</h1>
+<ul>
+  <li>こちらは移行例も兼ねたサンプル集です。移行前のv1決済フォームは<a href="./v1.html" target="_blank">こちら</a></li>
+  <li>テストカードは<a href="https://pay.jp/docs/testcard" target="_blank">こちら</a></li>
+  <li>このフォームのソースコードは<a href="https://github.com/payjp/payjp.github.io/blob/master/sample/payjp-js/index.html" target="_blank">こちら</a></li>
+</ul>
+<section class="mdc" id="v2-mdc">
+  <h2>マテリアルデザイン調</h2>
   <form>
     <div class="row">
-      <div class="field">
-        <div id="example-mdc-card-number" class="input"></div>
-        <label for="example-mdc-card-number">カード番号</label>
-        <div class="baseline"></div>
-      </div>
+      <label class="field text-field" for="v2-mdc-card-number">
+        <div id="v2-mdc-card-number" class="text-field__input"></div>
+        <span class="text-field__ripple"></span>
+        <span class="floating-label">カード番号</span>
+        <span class="line-ripple"></span>
+      </label>
     </div>
     <div class="row">
-      <div class="field half-width">
-        <div id="example-mdc-card-expiry" class="input"></div>
-        <label for="example-mdc-card-expiry">有効期限</label>
-        <div class="baseline"></div>
-      </div>
-      <div class="field half-width">
-        <div id="example-mdc-card-cvc" class="input"></div>
-        <label for="example-mdc-card-cvc">CVC</label>
-        <div class="baseline"></div>
-      </div>
+      <label class="field text-field" for="v2-mdc-card-expiry">
+        <div id="v2-mdc-card-expiry" class="text-field__input"></div>
+        <span class="text-field__ripple"></span>
+        <span class="floating-label">有効期限</span>
+        <span class="line-ripple"></span>
+      </label>
+      <label class="field text-field" for="v2-mdc-card-cvc">
+        <div id="v2-mdc-card-cvc" class="text-field__input"></div>
+        <span class="text-field__ripple"></span>
+        <span class="floating-label">CVC</span>
+        <span class="line-ripple"></span>
+      </label>
     </div>
     <div class="row">
-      <div class="field">
-        <input id="example-mdc-name" class="input PayjpElement PayjpElement--empty" type="text" placeholder="PAY KUN" autocomplete="name" required>
-        <label for="example-mdc-name">名義</label>
-        <div class="baseline"></div>
-      </div>
+      <label class="field mdc-text-field mdc-text-field--filled">
+        <span class="mdc-text-field__ripple"></span>
+        <span class="mdc-floating-label">名義</span>
+        <input id="v2-mdc-name"
+               class="mdc-text-field__input"
+               autocomplete="cc-name"
+               type="text"
+               placeholder="PAY KUN"
+        >
+        <span class="mdc-line-ripple"></span>
+      </label>
     </div>
-    <div class="error" role="alert">
-      <span class="message"></span>
+    <div class="row">
+      <button class="field mdc-button mdc-button--raised">
+        <span class="mdc-button__label">カード情報を送信する</span>
+      </button>
     </div>
-    <button type="submit">カード情報を送信する</button>
+    <div class="row error" role="alert">
+      <span class="field message"></span>
+    </div>
   </form>
   <div class="success">
     <h2 class="title">入力が完了しました！</h2>
@@ -257,134 +86,129 @@ section.example-mdc .input.PayjpElement--focus.PayjpElement--invalid + label + .
   </div>
 </section>
 </main>
+<script src="mdc.js"></script>
 <script type="text/javascript">
-var payjp = Payjp('pk_test_0383a1b8f91e8a6e3ea0e2a9')
+(function() {
+  var buttonElm = setUpMDC()
+  if (Payjp && buttonElm !== null) {
+    var payjp = Payjp('pk_test_0383a1b8f91e8a6e3ea0e2a9')
+    var elements = payjp.elements()
 
+    var elementStyle = {
+      base: {
+        fontFamily: '\'Noto Sans Japanese\', sans-serif',
+        '::placeholder': {
+          color: 'rgba(0, 0, 0, 0.54)',
+        },
+        caretColor: '#198FCC',
+        lineHeight: '28px',
+      },
+      invalid: {
+        color: 'rgba(0, 0, 0, 0.87)',
+      },
+    }
+    var numberElement = elements.create('cardNumber', {
+      style: elementStyle,
+      placeholder: '4242 4242 4242 4242'
+    })
+    var expiryElement = elements.create('cardExpiry', {
+      style: elementStyle,
+    })
+    var cvcElement = elements.create('cardCvc', {
+      style: elementStyle,
+    })
+    numberElement.mount('#v2-mdc-card-number')
+    expiryElement.mount('#v2-mdc-card-expiry')
+    cvcElement.mount('#v2-mdc-card-cvc')
 
-// setup PayjpElements
-var elements = payjp.elements({
-  locale: 'ja'
-})
+    var payjpElements = [numberElement, expiryElement, cvcElement]
+    var nameInput = document.querySelector('#v2-mdc-name')
 
-var elementStyle = {
-  base: {
-    fontWeight: 500,
-    fontFamily: '\'Noto Sans Japanese\', sans-serif',
-    fontSize: '16px',
-    '::placeholder': {
-      color: '#E0E0E0',
-    },
-  },
-  invalid: {
-    color: 'red',
-    '::placeholder': {
-      color: 'red',
-    },
-  },
-}
-var numberElement = elements.create('cardNumber', {
-  style: elementStyle,
-  placeholder: '4242 4242 4242 4242'
-})
-var expiryElement = elements.create('cardExpiry', {
-  style: elementStyle,
-})
-var cvcElement = elements.create('cardCvc', {
-  style: elementStyle,
-})
-numberElement.mount('#example-mdc-card-number')
-expiryElement.mount('#example-mdc-card-expiry')
-cvcElement.mount('#example-mdc-card-cvc')
+    var section = document.querySelector('section#v2-mdc')
+    var form = section.querySelector('form')
+    var errorElm = section.querySelector('.error')
 
-// setup optional input forms
-var nameInput = document.querySelector('#example-mdc-name')
-nameInput.addEventListener('focus', function() {
-  nameInput.classList.add('PayjpElement--focus');
-});
-nameInput.addEventListener('blur', function() {
-  nameInput.classList.remove('PayjpElement--focus');
-});
-nameInput.addEventListener('keyup', function() {
-  if (nameInput.value.length === 0) {
-    nameInput.classList.add('PayjpElement--empty');
-  } else {
-    nameInput.classList.remove('PayjpElement--empty');
-  }
-})
-
-var section = document.querySelector('section.example-mdc')
-setup([numberElement, expiryElement, cvcElement], section, {name: nameInput})
-
-function setup(elements, section, optionElms) {
-  var form = section.querySelector('form')
-  var buttonElm = form.querySelector('button')
-  var errorElm = form.querySelector('.error')
-  var errorMsgElm = errorElm.querySelector('.message')
-
-  // setup EventListener for PayjpElements
-  var errorMsgs = {}
-  elements.forEach(function(element, idx) {
-    element.on('change', function(event) {
-      if (event.error) {
-        errorElm.classList.add('visible')
-        errorMsgs[idx] = event.error.message
-        errorMsgElm.innerText = event.error.message
+    function displayErrorMsg(msg) {
+      errorElm.classList.add('visible')
+      errorElm.querySelector('.message').innerText = msg
+    }
+    // 入力値のバリデーション結果を表示
+    var changes = {}
+    payjpElements.forEach(function(element, idx) {
+      changes[idx] = null
+      element.on('change', function(event) {
+        changes[idx] = event
         buttonElm.setAttribute('disabled', 'true')
-      } else {
-        errorMsgs[idx] = null
-        var errorMsg = Object.keys(errorMsgs).sort().reduce(function(msg, i) {
-          return msg || errorMsgs[i]
-        }, null)
-
-        if (errorMsg) {
-          errorMsgElm.innerText = errorMsg
-          buttonElm.setAttribute('disabled', 'true')
+        if (event.error) {
+          displayErrorMsg(event.error.message)
         } else {
-          errorElm.classList.remove('visible')
-          buttonElm.removeAttribute('disabled')
+          var errorMsg = Object.keys(changes).sort().reduce(function(msg, i) {
+            if (msg) {
+              return msg
+            } else if (changes[i] && changes[i].error) {
+              return changes[i].error.message
+            }
+            return null
+          }, null)
+
+          if (errorMsg) {
+            displayErrorMsg(errorMsg)
+          } else {
+            errorElm.classList.remove('visible')
+            buttonElm.removeAttribute('disabled')
+          }
+        }
+      })
+    })
+
+    form.addEventListener('submit', function(e) {
+      e.preventDefault()
+      if (!Object.keys(changes).sort().reduce(function(prev, i) {
+        return prev && changes[i] && changes[i].complete
+      }, true)) {
+        return displayErrorMsg('入力が完了していません。')
+      }
+
+      var options = {
+        card: {
+          name: nameInput.value || undefined
         }
       }
-    })
-  })
 
-  form.addEventListener('submit', function(e) {
-    e.preventDefault()
+      buttonElm.setAttribute('disabled', 'true')
+      form.classList.add('submitting')
 
-    form.classList.add('submitting')
-    buttonElm.setAttribute('disabled', 'true')
-
-    // for optional input form
-    var options = {card: {}}
-    Object.keys(optionElms).forEach(function(key) {
-      options.card[key] = optionElms[key].value || undefined
-    })
-
-    payjp.createToken(elements[0], options).then(function(result) {
-      form.classList.remove('submitting')
-
-      if (result.id) {
-        section.querySelector('.token').innerText = result.id
-        form.classList.add('submitted')
-      } else {
-        errorElm.classList.add('visible')
-        errorMsgElm.innerText = result.error.message
+      payjp.createToken(payjpElements[0], options).then(function(result) {
+        form.classList.remove('submitting')
         buttonElm.removeAttribute('disabled')
-      }
-    });
-  });
 
-  section.querySelector('a.reset').addEventListener('click', function(e) {
-    e.preventDefault()
-
-    // cleanup
-    form.reset()
-    elements.forEach(function(element) {
-      element.clear()
+        if (result.id) {
+          section.querySelector('.token').innerText = result.id
+          form.classList.add('submitted')
+        } else {
+          displayErrorMsg(result.error.message)
+        }
+      })
     })
-    nameInput.classList.add('PayjpElement--empty');
-    buttonElm.removeAttribute('disabled')
-    errorElm.classList.remove('visible')
-    form.classList.remove('submitted')
-  });
-}
+
+    // クリーンアップ処理
+    section.querySelector('a.reset').addEventListener('click', function(e) {
+      e.preventDefault()
+
+      form.reset()
+
+      payjpElements.forEach(function(element) {
+        element.clear()
+      })
+      nameInput.parentElement.classList.remove('mdc-text-field--label-floating')
+      var labelElm = nameInput.parentElement.querySelector('.mdc-floating-label--float-above')
+      if (labelElm) {
+        labelElm.classList.remove('mdc-floating-label--float-above')
+      }
+
+      errorElm.classList.remove('visible')
+      form.classList.remove('submitted')
+    })
+  }
+})()
 </script>

--- a/sample/payjp-js/index.html
+++ b/sample/payjp-js/index.html
@@ -28,7 +28,7 @@
 <main>
 <h1>payjp.js v2 決済フォーム</h1>
 <ul>
-  <li>こちらは移行例も兼ねたサンプル集です。移行前のv1決済フォームは<a href="./v1.html" target="_blank">こちら</a></li>
+  <li>payjp.js v2を利用した決済フォームのサンプル集です</li>
   <li>テストカードは<a href="https://pay.jp/docs/testcard" target="_blank">こちら</a></li>
   <li>このフォームのソースコードは<a href="https://github.com/payjp/payjp.github.io/blob/master/sample/payjp-js/index.html" target="_blank">こちら</a></li>
 </ul>

--- a/sample/payjp-js/mdc-common.css
+++ b/sample/payjp-js/mdc-common.css
@@ -1,0 +1,37 @@
+section.mdc .row {
+  display: flex;
+  margin-bottom: 10px;
+}
+
+section.mdc .field {
+  position: relative;
+  width: 100%;
+  margin: 0 10px;
+}
+
+section.mdc * {
+  font-family: 'Noto Sans Japanese', sans-serif;
+}
+
+/* 各所のMDCデフォルトのカラーリングを上書き */
+/* カーソル */
+section.mdc .mdc-text-field:not(.mdc-text-field--invalid) .mdc-text-field__input {
+  caret-color: #198fcc;
+  caret-color: var(--payjp-primary-color);
+}
+/* ラベル */
+section.mdc .mdc-text-field--focused:not(.mdc-text-field--invalid) .mdc-floating-label {
+  color: #198fcc;
+  color: var(--payjp-primary-color);
+}
+
+/* ボーダーライン */
+section.mdc .mdc-text-field--filled:not(.mdc-text-field--invalid) .mdc-line-ripple::after {
+  border-bottom-color: #198fcc;
+  border-bottom-color: var(--payjp-primary-color);
+}
+/* ボタン */
+section.mdc .mdc-button.mdc-button--raised:not(:disabled) {
+  background-color: #198fcc;
+  background-color: var(--payjp-primary-color);
+}

--- a/sample/payjp-js/mdc-on-v2.css
+++ b/sample/payjp-js/mdc-on-v2.css
@@ -1,0 +1,122 @@
+/* 入力欄(Payjp Element)外枠のスタイル */
+.mdc .text-field {
+  background-color: whitesmoke;
+  height: 56px;
+  padding: 0 16px;
+  border-radius: 4px 4px 0 0;
+  display: inline-flex;
+  align-items: baseline;
+}
+.mdc .text-field::before {
+  display: inline-block;
+  width: 0;
+  height: 50px;
+  content: "";
+  vertical-align: 0;
+}
+.mdc .text-field__input {
+  width: 100%;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  /* プレースホルダーの非表示 */
+  opacity: 0;
+}
+
+/* 入力欄の重ねスタイル */
+.mdc .text-field__ripple {
+  background-color: rgba(0, 0, 0, 0.87);
+  opacity: 0;
+  position: absolute;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  transition: opacity 15ms linear;
+  z-index: 1;
+  pointer-events: none;
+}
+.mdc .text-field:hover .text-field__ripple {
+  opacity: 0.04;
+}
+
+/* ボーダーラインのスタイル */
+.mdc .text-field > .line-ripple {
+  position: absolute;
+  width: 100%;
+  height: 1px;
+  bottom: 0;
+  left: 0;
+  background-color: rgba(0, 0, 0, 0.42);
+  transition: transform 180ms cubic-bezier(0.4, 0, 0.2, 1),
+  color 180ms cubic-bezier(0.4, 0, 0.2, 1),
+  -webkit-transform 180ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* ラベルのスタイル */
+.mdc .text-field > .floating-label {
+  position: absolute;
+  color: rgba(0, 0, 0, 0.6);
+  left: 16px;
+  right: initial;
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  transform: translateY(-50%);
+  pointer-events: none;
+  line-height: 1.15rem;
+  font-size: 16px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+
+}
+
+/* ラベルの必須マーク */
+.mdc .text-field > .floating-label:after {
+  margin-left: 1px;
+  margin-right: 0px;
+  content: "*";
+}
+
+/* Elementコンテナの利用 */
+
+/* 入力欄周り */
+.mdc div.PayjpElement--focus ~ .text-field__ripple {
+  transition-duration: 75ms;
+  opacity: 0.12;
+}
+/* プレースホルダーの表示 */
+.mdc div.PayjpElement--focus,
+.mdc div.PayjpElement:not(.PayjpElement--empty) {
+  opacity: 1;
+}
+/* ラベルのアニメーション */
+.mdc div.PayjpElement--focus ~ .floating-label,
+.mdc div.PayjpElement:not(.PayjpElement--empty) ~ .floating-label {
+  transform: translateY(-20px) scale(0.75);
+  transform-origin: left top;
+  transition: transform 150ms cubic-bezier(0.4, 0, 0.2, 1),
+  color 150ms cubic-bezier(0.4, 0, 0.2, 1),
+  -webkit-transform 150ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* 各カラーリングをmdcライブラリと合わせる */
+/* カーソル: style引数で渡すため不要 */
+/* ラベル */
+.mdc div.PayjpElement--focus ~ .floating-label {
+  color: #198fcc;
+  color: var(--payjp-primary-color);
+}
+/* ラベル(エラー時) */
+.mdc div.PayjpElement--invalid ~ .floating-label {
+  color: #b00020;
+  color: var(--invalid-color);
+}
+/* ボーダーライン */
+.mdc div.PayjpElement--focus ~ .line-ripple {
+  background-color: #198fcc;
+  background-color: var(--payjp-primary-color);
+}
+/* ボーダーライン(エラー時) */
+.mdc div.PayjpElement--invalid ~ .line-ripple {
+  background-color: #b00020;
+  background-color: var(--invalid-color);
+}

--- a/sample/payjp-js/mdc.js
+++ b/sample/payjp-js/mdc.js
@@ -1,0 +1,12 @@
+// Material Component Webの初期化
+function setUpMDC() {
+  if (!mdc) {
+    return null
+  }
+  mdc.ripple.MDCRipple.attachTo(document.querySelector('form'));
+  document.querySelectorAll('.mdc-text-field').forEach(function (e) {
+    new mdc.textField.MDCTextField(e);
+  })
+  buttonRipple = new mdc.ripple.MDCRipple(document.querySelector('.mdc-button'))
+  return buttonRipple.root
+}

--- a/sample/payjp-js/v1.html
+++ b/sample/payjp-js/v1.html
@@ -25,7 +25,7 @@
 <main>
 <h1>payjp.js v1 (Deprecated) 決済フォーム</h1>
 <ul>
-  <li>こちらは移行例のサンプル集です。移行先のv2決済フォームは<a href="./index.html" target="_blank">こちら</a></li>
+  <li><a href="https://pay.jp/docs/migrate-payjs-v1">v1提供終了に伴う移行</a>のサンプルです。移行先のv2決済フォームは<a href="./index.html" target="_blank">こちら</a></li>
   <li>テストカードは<a href="https://pay.jp/docs/testcard" target="_blank">こちら</a></li>
   <li>このフォームのソースコードは<a href="https://github.com/payjp/payjp.github.io/blob/master/sample/payjp-js/v1.html" target="_blank">こちら</a></li>
 </ul>

--- a/sample/payjp-js/v1.html
+++ b/sample/payjp-js/v1.html
@@ -1,0 +1,287 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta content="width=device-width,initial-scale=1.0" name="viewport">
+<title>payjp.js v1 (Deprecated) sample for migration</title>
+<script type="text/javascript" src="https://js.pay.jp/v1/"></script>
+<!-- for IE11 -->
+<script>
+  window.MSInputMethodContext
+  && document.documentMode
+  && document.write(
+    '<script src="https://cdnjs.cloudflare.com/ajax/libs/bluebird/3.3.4/bluebird.min.js"><\/script>'
+  )
+</script>
+<!-- end: for IE11 -->
+<!-- material design library -->
+<script src="https://unpkg.com/material-components-web@latest/dist/material-components-web.min.js"></script>
+<link href="https://unpkg.com/material-components-web@latest/dist/material-components-web.min.css" rel="stylesheet">
+<!-- end: material design library -->
+<link rel="stylesheet" type="text/css" href="base.css" />
+<link rel="stylesheet" type="text/css" href="mdc-common.css" />
+</head>
+<body>
+<main>
+<h1>payjp.js v1 (Deprecated) 決済フォーム</h1>
+<ul>
+  <li>こちらは移行例のサンプル集です。移行先のv2決済フォームは<a href="./index.html" target="_blank">こちら</a></li>
+  <li>テストカードは<a href="https://pay.jp/docs/testcard" target="_blank">こちら</a></li>
+  <li>このフォームのソースコードは<a href="https://github.com/payjp/payjp.github.io/blob/master/sample/payjp-js/v1.html" target="_blank">こちら</a></li>
+</ul>
+<section class="mdc" id="v1">
+  <h2>マテリアルデザイン調</h2>
+  <form>
+    <div class="row">
+      <label class="field mdc-text-field mdc-text-field--filled">
+        <span class="mdc-text-field__ripple"></span>
+        <span class="mdc-floating-label">カード番号</span>
+        <input id="v1-card-number"
+               class="mdc-text-field__input"
+               autocomplete="cc-number"
+               autocorrect="off"
+               spellcheck="false"
+               inputmode="numeric"
+               placeholder="4242 4242 4242 4242"
+               required
+        >
+        <span class="mdc-line-ripple"></span>
+      </label>
+    </div>
+    <div class="row">
+      <label class="field mdc-text-field mdc-text-field--filled">
+        <span class="mdc-text-field__ripple"></span>
+        <span class="mdc-floating-label">月</span>
+        <input id="v1-card-expiry-month"
+               class="mdc-text-field__input"
+               autocomplete="cc-exp-month"
+               autocorrect="off"
+               spellcheck="false"
+               type="number"
+               placeholder="12"
+               required
+        >
+        <span class="mdc-line-ripple"></span>
+      </label>
+      <label class="field mdc-text-field mdc-text-field--filled">
+        <span class="mdc-text-field__ripple"></span>
+        <span class="mdc-floating-label">年</span>
+        <input id="v1-card-expiry-year"
+               class="mdc-text-field__input"
+               autocomplete="cc-exp-year"
+               autocorrect="off"
+               spellcheck="false"
+               type="number"
+               placeholder="2025"
+               required
+        >
+        <span class="mdc-line-ripple"></span>
+      </label>
+      <label class="field mdc-text-field mdc-text-field--filled">
+        <span class="mdc-text-field__ripple"></span>
+        <span class="mdc-floating-label">CVC</span>
+        <input id="v1-card-cvc"
+               class="mdc-text-field__input"
+               autocomplete="cc-csc"
+               autocorrect="off"
+               spellcheck="false"
+               type="number"
+               placeholder="CVC"
+               max-length="4"
+               required
+        >
+        <span class="mdc-line-ripple"></span>
+      </label>
+    </div>
+    <div class="row">
+      <label class="field mdc-text-field mdc-text-field--filled">
+        <span class="mdc-text-field__ripple"></span>
+        <span class="mdc-floating-label">名義</span>
+        <input id="v1-name"
+               class="mdc-text-field__input"
+               autocomplete="cc-name"
+               type="text"
+               placeholder="PAY KUN"
+        >
+        <span class="mdc-line-ripple"></span>
+      </label>
+    </div>
+    <div class="row">
+      <button class="field mdc-button mdc-button--raised">
+        <span class="mdc-button__label">カード情報を送信する</span>
+      </button>
+    </div>
+    <div class="row error" role="alert">
+      <span class="field message"></span>
+    </div>
+  </form>
+  <div class="success">
+    <h2 class="title">入力が完了しました！</h2>
+    <p class="message"><span>token: </span><span class="token"></span></p>
+    <a class="reset" href="#">入力フォームに戻る</a>
+  </div>
+</section>
+</main>
+<script src="mdc.js"></script>
+<script type="text/javascript">
+(function() {
+  var buttonElm = setUpMDC()
+  if (Payjp && buttonElm !== null) {
+    Payjp.setPublicKey('pk_test_0383a1b8f91e8a6e3ea0e2a9')
+
+    var numberInput = document.querySelector('#v1-card-number')
+    var expMonthInput = document.querySelector('#v1-card-expiry-month')
+    var expYearInput = document.querySelector('#v1-card-expiry-year')
+    var cvcInput = document.querySelector('#v1-card-cvc')
+    // optional input forms
+    var nameInput = document.querySelector('#v1-name')
+
+    var elements = [
+      numberInput,
+      expMonthInput,
+      expYearInput,
+      cvcInput,
+      nameInput,
+    ]
+
+    var section = document.querySelector('section#v1')
+    var form = section.querySelector('form')
+    var errorElm = section.querySelector('.error')
+
+    // 入力値の整形や制限 (v2ではライブラリが行ってくれます)
+    numberInput.addEventListener('input', function(e) {
+      // 数値以外の入力を強制削除 & フォーマット(4桁ごとにスペースを追加)
+      var numberStr = e.target.value.replace(/\D/g, '').slice(0, 17)
+      var displayedNumber = ''
+      for (var i = 0;i < numberStr.length / 4;i++) {
+        displayedNumber += numberStr.slice(i * 4, i * 4 + 4) + ' '
+      }
+      e.target.value = displayedNumber.trim()
+    })
+    expMonthInput.addEventListener('input', function(e) {
+      e.target.value = e.target.value.replace(/\D/g, '').slice(0, 2)
+    })
+    expYearInput.addEventListener('input', function(e) {
+      e.target.value = e.target.value.replace(/\D/g, '').slice(0, 4)
+    })
+    cvcInput.addEventListener('input', function(e) {
+      e.target.value = e.target.value.replace(/\D/g, '').slice(0, 4)
+    })
+
+    // 入力値のバリデーション (v2ではライブラリが行ってくれます)
+    var completes = {number: false, expiry: false, cvc: false}
+    numberInput.addEventListener('blur', function(e) {
+      var prev = completes.number
+      completes.number = validNumber(e.target.value.replace(/\s/g, ''))
+      if (!prev && completes.number) {
+        errorElm.classList.remove('visible')
+      }
+    })
+    expMonthInput.addEventListener('blur', function(e) {
+      var prev = completes.expiry
+      completes.expiry = validExpiry(e.target.value, expYearInput.value || '9999')
+      if (!prev && completes.expiry) {
+        errorElm.classList.remove('visible')
+      }
+    })
+    expYearInput.addEventListener('blur', function(e) {
+      var prev = completes.expiry
+      completes.expiry = validExpiry(expMonthInput.value || '12', e.target.value)
+      if (!prev && completes.expiry) {
+        errorElm.classList.remove('visible')
+      }
+    })
+    cvcInput.addEventListener('blur', function(e) {
+      var prev = completes.cvc
+      completes.cvc = validCvc(e.target.value)
+      if (!prev && completes.cvc) {
+        errorElm.classList.remove('visible')
+      }
+    })
+
+    function displayErrorMsg(msg) {
+      errorElm.classList.add('visible')
+      errorElm.querySelector('.message').innerText = msg
+    }
+    function validNumber(value) {
+      numberInput.parentElement.classList.remove('mdc-text-field--invalid')
+      var valid = Payjp.validate.cardNumber(value)
+      if (!valid) {
+        numberInput.parentElement.classList.add('mdc-text-field--invalid')
+        displayErrorMsg('カード番号が正しくありません')
+      }
+      return valid
+    }
+    function validExpiry(month, year) {
+      expMonthInput.parentElement.classList.remove('mdc-text-field--invalid')
+      expYearInput.parentElement.classList.remove('mdc-text-field--invalid')
+
+      var valid = Payjp.validate.expiry(month, year)
+      if (!valid) {
+        expMonthInput.parentElement.classList.add('mdc-text-field--invalid')
+        expYearInput.parentElement.classList.add('mdc-text-field--invalid')
+        displayErrorMsg('有効期限が正しくありません')
+      }
+      return valid
+    }
+    function validCvc(value) {
+      cvcInput.parentElement.classList.remove('mdc-text-field--invalid')
+
+      var valid = Payjp.validate.cvc(value)
+      if (!valid) {
+        cvcInput.parentElement.classList.add('mdc-text-field--invalid')
+        displayErrorMsg('CVCが正しくありません')
+      }
+      return valid
+    }
+
+    form.addEventListener('submit', function(e) {
+      e.preventDefault()
+
+      var card = {
+        number: numberInput.value.replace(/\s/g, ''),
+        cvc: cvcInput.value,
+        exp_month: expMonthInput.value,
+        exp_year: expYearInput.value,
+        name: nameInput.value // optional
+      }
+      if (!validNumber(card.number) || !validExpiry(card.exp_month, card.exp_year) || !validCvc(card.cvc)) {
+        return
+      }
+
+      buttonElm.setAttribute('disabled', 'true')
+      form.classList.add('submitting')
+
+      Payjp.createToken(card, function (s, result) {
+        form.classList.remove('submitting')
+        buttonElm.removeAttribute('disabled')
+
+        if (s === 200 && result.id) {
+          section.querySelector('.token').innerText = result.id
+          form.classList.add('submitted')
+        } else {
+          displayErrorMsg(result.error.message)
+        }
+      })
+    })
+
+    // クリーンアップ処理
+    section.querySelector('a.reset').addEventListener('click', function(e) {
+      e.preventDefault()
+
+      form.reset()
+
+      elements.forEach(function(element) {
+        element.parentElement.classList.remove('mdc-text-field--label-floating')
+        var labelElm = element.parentElement.querySelector('.mdc-floating-label--float-above')
+        if (labelElm) {
+          labelElm.classList.remove('mdc-floating-label--float-above')
+        }
+      })
+
+      errorElm.classList.remove('visible')
+      form.classList.remove('submitted')
+    })
+  }
+})()
+</script>


### PR DESCRIPTION
## 概要

v1を近く廃止にします。それに伴い、v1を利用する加盟店はv2への移行が必要となるので、デザインサンプルを用意します。
メジャーなデザインであるmaterial designを例に、v1からv2へ（ほぼ）同じデザインで移行する場合を想定しています。

## 変更点

`sample/payjp-js/index.html` について、以前はv1を利用した決済フォームサンプルを載せていたため、取り急ぎv2のデザインサンプルに修正しましたが、今回の比較用のデザインにするにあたり細かい部分など多くの修正が入りました。
差分を意識せず、新規ファイルとしてレビューいただきたいです。

## Ref

- マテリアルデザインライブラリ
  - https://material.io/components/text-fields